### PR TITLE
Prevent duplicate call of addMultipleCartItems

### DIFF
--- a/src/templates/products/includes/child_products.template.html
+++ b/src/templates/products/includes/child_products.template.html
@@ -158,7 +158,7 @@
                         </table>
                     </div>
                     <div class="cta-area">
-                        <a href="#" onclick="javascript:if ($.checkValidQty()) { $.addMultipleCartItems('multiitemadd'); return false; }" rel="nofollow" class="multi-add btn btn-success" title="Add [@model@] to Cart"><i class="fa fa-shopping-cart"></i> Add Selected to Cart</a>
+                        <div class="multi-add btn btn-success" title="Add Selected to Cart"><i class="fa fa-shopping-cart"></i> Add Selected to Cart</div>
                         <span id="a2c_loading"></span>
                     </div>
                 </div>


### PR DESCRIPTION
addMutlipleCartItems function being called twice on click of add to cart button, incorrectly displaying error message on product page.